### PR TITLE
Move to dotnet 5.0

### DIFF
--- a/MexFF/Commands/CmdFighterFunction.cs
+++ b/MexFF/Commands/CmdFighterFunction.cs
@@ -224,21 +224,30 @@ and injects it into PlMan.dat with the symbol name itFunction";
             if (inputs.Length == 0)
                 return null;
 
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-                throw new Exception("Invalid platform " + Environment.OSVersion.Platform.ToString());
+            bool isWindows = (Environment.OSVersion.Platform == PlatformID.Win32NT);
 
-            var devkitpath = Environment.GetEnvironmentVariable("DEVKITPPC").Replace("/opt/", "C:/");
+            var devkitpath = Environment.GetEnvironmentVariable("DEVKITPPC");
 
             if (string.IsNullOrEmpty(devkitpath))
                 throw new FileNotFoundException("DEVKITPPC path not set");
 
-            var gccPath = Path.Combine(devkitpath, "bin/powerpc-eabi-gcc.exe");
+            if(isWindows)
+                devkitpath = devkitpath.Replace("/opt/", "C:/");
+
+            string gccRelPath;
+
+            if(isWindows)
+                gccRelPath = "bin/powerpc-eabi-gcc.exe";
+            else
+                gccRelPath = "bin/powerpc-eabi-gcc";
+
+            var gccPath = Path.Combine(devkitpath, gccRelPath);
 
             if (!File.Exists(gccPath))
                 gccPath = gccPath.Replace("C:/", "");
 
             if (!File.Exists(gccPath))
-                throw new FileNotFoundException("powerpc-eabi-gcc.exe not found at " + gccPath);
+                throw new FileNotFoundException("powerpc-eabi-gcc not found at " + gccPath);
 
             var ext = Path.GetExtension(inputs[0]).ToLower();
             List<RelocELF> elfs = new List<RelocELF>();

--- a/MexFF/MexTK.csproj
+++ b/MexFF/MexTK.csproj
@@ -9,30 +9,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>./HSDRaw.dll</HintPath>
     </Reference>
-    <!--<Reference Include="netstandard" />-->
   </ItemGroup>
-  <!--<ItemGroup>
-    <Compile Include="Commands/Animation/CmdRetargetAnimation.cs" />
-    <Compile Include="Commands/CmdAddSymbol.cs" />
-    <Compile Include="Commands/CmdFighterFunction.cs" />
-    <Compile Include="Commands/Animation/CmdOptimizeFigatree.cs" />
-    <Compile Include="Commands/Animation/CmdPortFigatree.cs" />
-    <Compile Include="Commands/CmdTrimDAT.cs" />
-    <Compile Include="Commands/ICommand.cs" />
-    <Compile Include="Commands/MEX/CmdCspCompressor.cs" />
-    <Compile Include="FighterFunction/LinkFile.cs" />
-    <Compile Include="FighterFunction/Enums.cs" />
-    <Compile Include="Tools/AnimationBakery.cs" />
-    <Compile Include="Tools/BoneMap.cs" />
-    <Compile Include="Properties/AssemblyInfo.cs" />
-    <Compile Include="FighterFunction/RelocELF.cs" />
-    <Compile Include="FighterFunction/Structs.cs" />
-    <Compile Include="Tools/DatTools.cs" />
-    <Compile Include="Tools/FileTools.cs" />
-    <Compile Include="Tools/ImageTools.cs" />
-    <Compile Include="Tools/KeyReducer.cs" />
-    <Compile Include="Tools/SkeletonPorter.cs" />
-  </ItemGroup>-->
   <ItemGroup>
     <Content Include="HSDRaw.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -43,26 +20,4 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
-  <!--<ItemGroup>
-    <Compile Remove="Commands/Animation/CmdOptimizeFigatree.cs" />
-    <Compile Remove="Commands/Animation/CmdPortFigatree.cs" />
-    <Compile Remove="Commands/Animation/CmdRetargetAnimation.cs" />
-    <Compile Remove="Commands/CmdAddSymbol.cs" />
-    <Compile Remove="Commands/CmdFighterFunction.cs" />
-    <Compile Remove="Commands/CmdTrimDAT.cs" />
-    <Compile Remove="Commands/ICommand.cs" />
-    <Compile Remove="Commands/MEX/CmdCspCompressor.cs" />
-    <Compile Remove="FighterFunction/Enums.cs" />
-    <Compile Remove="FighterFunction/LinkFile.cs" />
-    <Compile Remove="FighterFunction/RelocELF.cs" />
-    <Compile Remove="FighterFunction/Structs.cs" />
-    <Compile Remove="Properties/AssemblyInfo.cs" />
-    <Compile Remove="Tools/AnimationBakery.cs" />
-    <Compile Remove="Tools/BoneMap.cs" />
-    <Compile Remove="Tools/DatTools.cs" />
-    <Compile Remove="Tools/FileTools.cs" />
-    <Compile Remove="Tools/ImageTools.cs" />
-    <Compile Remove="Tools/KeyReducer.cs" />
-    <Compile Remove="Tools/SkeletonPorter.cs" />
-  </ItemGroup>-->
 </Project>

--- a/MexFF/MexTK.csproj
+++ b/MexFF/MexTK.csproj
@@ -1,86 +1,68 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{25977C46-EF89-451F-9987-64C4184B9F50}</ProjectGuid>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RootNamespace>MexTK</RootNamespace>
-    <AssemblyName>MexTK</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="HSDRaw, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>.\HSDRaw.dll</HintPath>
+      <HintPath>./HSDRaw.dll</HintPath>
     </Reference>
-    <Reference Include="netstandard" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <!--<Reference Include="netstandard" />-->
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Commands\Animation\CmdRetargetAnimation.cs" />
-    <Compile Include="Commands\CmdAddSymbol.cs" />
-    <Compile Include="Commands\CmdFighterFunction.cs" />
-    <Compile Include="Commands\Animation\CmdOptimizeFigatree.cs" />
-    <Compile Include="Commands\Animation\CmdPortFigatree.cs" />
-    <Compile Include="Commands\CmdTrimDAT.cs" />
-    <Compile Include="Commands\ICommand.cs" />
-    <Compile Include="Commands\MEX\CmdCspCompressor.cs" />
-    <Compile Include="FighterFunction\LinkFile.cs" />
-    <Compile Include="FighterFunction\Enums.cs" />
-    <Compile Include="Tools\AnimationBakery.cs" />
-    <Compile Include="Tools\BoneMap.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="FighterFunction\RelocELF.cs" />
-    <Compile Include="FighterFunction\Structs.cs" />
-    <Compile Include="Tools\DatTools.cs" />
-    <Compile Include="Tools\FileTools.cs" />
-    <Compile Include="Tools\ImageTools.cs" />
-    <Compile Include="Tools\KeyReducer.cs" />
-    <Compile Include="Tools\SkeletonPorter.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
+  <!--<ItemGroup>
+    <Compile Include="Commands/Animation/CmdRetargetAnimation.cs" />
+    <Compile Include="Commands/CmdAddSymbol.cs" />
+    <Compile Include="Commands/CmdFighterFunction.cs" />
+    <Compile Include="Commands/Animation/CmdOptimizeFigatree.cs" />
+    <Compile Include="Commands/Animation/CmdPortFigatree.cs" />
+    <Compile Include="Commands/CmdTrimDAT.cs" />
+    <Compile Include="Commands/ICommand.cs" />
+    <Compile Include="Commands/MEX/CmdCspCompressor.cs" />
+    <Compile Include="FighterFunction/LinkFile.cs" />
+    <Compile Include="FighterFunction/Enums.cs" />
+    <Compile Include="Tools/AnimationBakery.cs" />
+    <Compile Include="Tools/BoneMap.cs" />
+    <Compile Include="Properties/AssemblyInfo.cs" />
+    <Compile Include="FighterFunction/RelocELF.cs" />
+    <Compile Include="FighterFunction/Structs.cs" />
+    <Compile Include="Tools/DatTools.cs" />
+    <Compile Include="Tools/FileTools.cs" />
+    <Compile Include="Tools/ImageTools.cs" />
+    <Compile Include="Tools/KeyReducer.cs" />
+    <Compile Include="Tools/SkeletonPorter.cs" />
+  </ItemGroup>-->
   <ItemGroup>
     <Content Include="HSDRaw.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+  </ItemGroup>
+  <!--<ItemGroup>
+    <Compile Remove="Commands/Animation/CmdOptimizeFigatree.cs" />
+    <Compile Remove="Commands/Animation/CmdPortFigatree.cs" />
+    <Compile Remove="Commands/Animation/CmdRetargetAnimation.cs" />
+    <Compile Remove="Commands/CmdAddSymbol.cs" />
+    <Compile Remove="Commands/CmdFighterFunction.cs" />
+    <Compile Remove="Commands/CmdTrimDAT.cs" />
+    <Compile Remove="Commands/ICommand.cs" />
+    <Compile Remove="Commands/MEX/CmdCspCompressor.cs" />
+    <Compile Remove="FighterFunction/Enums.cs" />
+    <Compile Remove="FighterFunction/LinkFile.cs" />
+    <Compile Remove="FighterFunction/RelocELF.cs" />
+    <Compile Remove="FighterFunction/Structs.cs" />
+    <Compile Remove="Properties/AssemblyInfo.cs" />
+    <Compile Remove="Tools/AnimationBakery.cs" />
+    <Compile Remove="Tools/BoneMap.cs" />
+    <Compile Remove="Tools/DatTools.cs" />
+    <Compile Remove="Tools/FileTools.cs" />
+    <Compile Remove="Tools/ImageTools.cs" />
+    <Compile Remove="Tools/KeyReducer.cs" />
+    <Compile Remove="Tools/SkeletonPorter.cs" />
+  </ItemGroup>-->
 </Project>


### PR DESCRIPTION
The reasoning is pretty clear: a move to dotnet 5.0/dotnet core allows for the programming to be multiplatform.