### PR TITLE
Restore Clean flag

### DIFF
--- a/MexFF/Commands/CmdFighterFunction.cs
+++ b/MexFF/Commands/CmdFighterFunction.cs
@@ -141,6 +141,9 @@ and injects it into PlMan.dat with the symbol name itFunction";
                 if (args[i] == "-w")
                     disableWarnings = false;
 
+                if (args[i] == "-c")
+                    clean = true;
+                    
                 if (args[i] == "-d")
                     debug = true;
 


### PR DESCRIPTION
Make clean flag be set when arg is present, seems like it was removed by mistake on [this commit](https://github.com/akaneia/MexTK/commit/ae42be601c3a3d71ab869c30bc8826647a1efb7d#diff-8b718ec7c15083b92c8fcd489610f06acf4ab3bc8e817dd64430fdbe95972638L125)