### PR TITLE
Fix cleanup exception due to attempting to delete a non-empty directory

### DIFF
--- a/MexFF/FighterFunction/Compiling.cs
+++ b/MexFF/FighterFunction/Compiling.cs
@@ -170,7 +170,7 @@ namespace MexTK.FighterFunction
             if (clean)
             {
                 if (Directory.Exists(buildPath)) 
-                    Directory.Delete(buildPath, recursive=true);
+                    Directory.Delete(buildPath, true);
             }
 
             return linkedElf;

--- a/MexFF/FighterFunction/Compiling.cs
+++ b/MexFF/FighterFunction/Compiling.cs
@@ -170,7 +170,7 @@ namespace MexTK.FighterFunction
             if (clean)
             {
                 if (Directory.Exists(buildPath)) 
-                    Directory.Delete(buildPath);
+                    Directory.Delete(buildPath, recursive=true);
             }
 
             return linkedElf;


### PR DESCRIPTION
Prevents the following exception when the cleanup '-c' flag is passed.

```
Unhandled Exception: System.IO.IOException: The directory is not empty.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean 
throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkH
ost)
   at System.IO.Directory.Delete(String path)
   at MexTK.FighterFunction.Compiling.Compile(String[] inputs, Boolean disableWarnings, Boolean clea
n, Int32 optimizationLevel, String[] includes, String buildPath, Boolean debugSymbols, Boolean quiet
, Boolean isCPP)
   at MexTK.Commands.CmdFighterFunction.CompileElfs(String[] inputs, Boolean disableWarnings, Boolea
n clean, Int32 optimizationLevel, String[] includes, String buildPath, Boolean debug, Boolean quiet,
 Boolean isCPP)
   at MexTK.Commands.CmdFighterFunction.DoIt(String[] args)
   at MexTK.Program.Main(String[] args)
```