### PR TITLE
Update warning flags

### DIFF
--- a/MexFF/FighterFunction/Compiling.cs
+++ b/MexFF/FighterFunction/Compiling.cs
@@ -104,8 +104,9 @@ namespace MexTK.FighterFunction
                             includesStr = $"-I{String.Join(" -I", includeList.ToArray())}";
                         }
 
-                        // add -g for debug symbols
-                        p.StartInfo.Arguments = $"-MMD -MP -MF \"{outputPathD}\" {(debugSymbols ? "-g" : "")} {(disableWarnings ? "-w" : "")} -O{optimizationLevel} -Wall -DGEKKO -mogc -mcpu=750 -meabi -mhard-float {includesStr} -c \"{input}\" -o \"{outputPath}\" -fpermissive";// -Wno-unused-variable";
+                        var warningFlags = "-Wall -Wextra -Wno-unused-variable -Wno-unused-function -Wno-builtin-declaration-mismatch";
+
+                        p.StartInfo.Arguments = $"-MMD -MP -MF \"{outputPathD}\" {(debugSymbols ? "-g" : "")} {(disableWarnings ? "-w" : "")} -O{optimizationLevel} {warningFlags} -DGEKKO -mogc -mcpu=750 -meabi -mhard-float {includesStr} -c \"{input}\" -o \"{outputPath}\" -fpermissive";
 
 
                         System.Diagnostics.Debug.WriteLine(p.StartInfo.Arguments);


### PR DESCRIPTION
It is currently difficult to turn on warnings for m-ex projects because of the torrent of warnings in the m-ex headers. This is a companion pr to [this pr](https://github.com/akaneia/m-ex/pull/14). 